### PR TITLE
refactor: switch to primaryKey

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/leaf.git",
         "state": {
           "branch": null,
-          "revision": "04f262edbee143cdfefc5b26cef704913712e16c",
-          "version": "4.2.1"
+          "revision": "bf1c27928c3f7f93fcdca570d7514727fa23e14e",
+          "version": "4.2.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "40a7b42b20c22253d53b09dc49c37fbb7973fdfe",
-          "version": "4.14.1"
+          "revision": "dc7666f774755be333f48f25c4d8bead0a1a6877",
+          "version": "4.14.2"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,11 +57,11 @@
       },
       {
         "package": "ParseSwift",
-        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
+        "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "dc7666f774755be333f48f25c4d8bead0a1a6877",
-          "version": "4.14.2"
+          "revision": "a0d9902b2c5227cfa2122f8ad6c187f788a73413",
+          "version": "4.15.0"
         }
       },
       {
@@ -80,6 +80,15 @@
           "branch": null,
           "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
           "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
         }
       },
       {
@@ -132,8 +141,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
-          "version": "2.40.0"
+          "revision": "bc4c55b9f9584f09eb971d67d956e28d08caa9d0",
+          "version": "2.43.1"
         }
       },
       {
@@ -186,8 +195,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "dda0de537e7906414dccd551e77095be1e34e3da",
-          "version": "4.65.2"
+          "revision": "43fc875b4faa27d23d9561e8c069357d3dec27f4",
+          "version": "4.66.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "a0d9902b2c5227cfa2122f8ad6c187f788a73413",
-          "version": "4.15.0"
+          "revision": "8c58ad28038d2d2894257ceba98ed1f3d2b11e0c",
+          "version": "4.15.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.66.1")),
         .package(url: "https://github.com/vapor/leaf.git", .upToNextMajor(from: "4.2.2")),
         .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-                 .upToNextMajor(from: "4.15.0")),
+                 .upToNextMajor(from: "4.15.1")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,9 @@ let package = Package(
     dependencies: [
         // 💧 A server-side Swift web framework.
         .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.65.2")),
-        .package(url: "https://github.com/vapor/leaf.git", .upToNextMajor(from: "4.2.1")),
+        .package(url: "https://github.com/vapor/leaf.git", .upToNextMajor(from: "4.2.2")),
         .package(url: "https://github.com/parse-community/Parse-Swift.git",
-                 .upToNextMajor(from: "4.14.1")),
+                 .upToNextMajor(from: "4.14.2")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,10 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.65.2")),
+        .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.66.1")),
         .package(url: "https://github.com/vapor/leaf.git", .upToNextMajor(from: "4.2.2")),
-        .package(url: "https://github.com/parse-community/Parse-Swift.git",
-                 .upToNextMajor(from: "4.14.2")),
+        .package(url: "https://github.com/netreconlab/Parse-Swift.git",
+                 .upToNextMajor(from: "4.15.0")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ guard let parseServerUrl = URL(string: "http://localhost:1337/1") else {
 // Initialize the Parse-Swift SDK
 ParseSwift.initialize(applicationId: "applicationId", // Required: Change to your applicationId.
                       clientKey: "clientKey", // Required: Change to your clientKey.
-                      masterKey: "masterKey", // Required: Change to your masterKey.
+                      primaryKey: "primaryKey", // Required: Change to your primaryKey.
                       serverURL: parseServerUrl,
                       usingPostForQuery: true) { _, completionHandler in
     completionHandler(.performDefaultHandling, nil)
@@ -139,9 +139,9 @@ app.post("bar",
         return ParseHookResponse(error: .init(code: .missingObjectId,
                                               message: "Object not sent in request."))
     }
-    // To query using the masterKey pass the `useMasterKey option
+    // To query using the primaryKey pass the `usePrimaryKey` option
     // to ther query.
-    let scores = try await GameScore.query.findAll(options: [.useMasterKey])
+    let scores = try await GameScore.query.findAll(options: [.usePrimaryKey])
     req.logger.info("All scores: \(scores)")
     return ParseHookResponse(success: object)
 }

--- a/Sources/ParseServerSwift/Documentation.docc/Cloud Code.tutorial
+++ b/Sources/ParseServerSwift/Documentation.docc/Cloud Code.tutorial
@@ -57,9 +57,9 @@
                         return ParseHookResponse(error: .init(code: .missingObjectId,
                                                               message: "Object not sent in request."))
                     }
-                    // To query using the masterKey pass the `useMasterKey option
+                    // To query using the primaryKey pass the `usePrimaryKey` option
                     // to ther query.
-                    let scores = try await GameScore.query.findAll(options: [.useMasterKey])
+                    let scores = try await GameScore.query.findAll(options: [.usePrimaryKey])
                     req.logger.info("All scores: \(scores)")
                     return ParseHookResponse(success: object)
                 }
@@ -179,9 +179,9 @@
                         return ParseHookResponse(error: .init(code: .missingObjectId,
                                                               message: "Object not sent in request."))
                     }
-                    // To query using the masterKey pass the `useMasterKey option
+                    // To query using the primaryKey pass the `usePrimaryKey` option
                     // to ther query.
-                    let scores = try await GameScore.query.findAll(options: [.useMasterKey])
+                    let scores = try await GameScore.query.findAll(options: [.usePrimaryKey])
                     req.logger.info("All scores: \(scores)")
                     return ParseHookResponse(success: object)
                 }

--- a/Sources/ParseServerSwift/Documentation.docc/Configuring Parse Server Swift.tutorial
+++ b/Sources/ParseServerSwift/Documentation.docc/Configuring Parse Server Swift.tutorial
@@ -38,7 +38,7 @@
                 // Initialize the Parse-Swift SDK
                 ParseSwift.initialize(applicationId: "applicationId", // Required: Change to your applicationId.
                                       clientKey: "clientKey", // Required: Change to your clientKey.
-                                      masterKey: "masterKey", // Required: Change to your masterKey.
+                                      primaryKey: "primaryKey", // Required: Change to your primaryKey.
                                       serverURL: parseServerUrl,
                                       usingPostForQuery: true) { _, completionHandler in
                     completionHandler(.performDefaultHandling, nil)

--- a/Sources/ParseServerSwift/Models/User.swift
+++ b/Sources/ParseServerSwift/Models/User.swift
@@ -1,6 +1,6 @@
 //
 //  User.swift
-//  
+//
 //
 //  Created by Corey E. Baker on 6/20/22.
 //
@@ -9,8 +9,8 @@ import Foundation
 import ParseSwift
 
 /**
- An example `ParseUser`. You will want to replace this
- with your version of `ParseUser`.
+ An example `ParseUser`. You will want to add custom
+ properties to reflect the `ParseUser` on your Parse Server.
  */
 struct User: ParseCloudUser {
 
@@ -25,4 +25,6 @@ struct User: ParseCloudUser {
     var ACL: ParseACL?
     var originalData: Data?
     var sessionToken: String?
+    // var _failed_login_count: Int?
+    // var _account_lockout_expires_at: Date?
 }

--- a/Sources/ParseServerSwift/configure.swift
+++ b/Sources/ParseServerSwift/configure.swift
@@ -35,7 +35,7 @@ public func configure(_ app: Application) throws {
     // Initialize the Parse-Swift SDK
     ParseSwift.initialize(applicationId: "applicationId", // Required: Change to your applicationId.
                           clientKey: "clientKey", // Required: Change to your clientKey.
-                          masterKey: "masterKey", // Required: Change to your masterKey.
+                          primaryKey: "primaryKey", // Required: Change to your primaryKey.
                           serverURL: parseServerUrl,
                           usingPostForQuery: true) { _, completionHandler in
         completionHandler(.performDefaultHandling, nil)

--- a/Sources/ParseServerSwift/routes.swift
+++ b/Sources/ParseServerSwift/routes.swift
@@ -54,9 +54,9 @@ func routes(_ app: Application) throws {
             return ParseHookResponse(error: .init(code: .missingObjectId,
                                                   message: "Object not sent in request."))
         }
-        // To query using the masterKey pass the `useMasterKey option
+        // To query using the primaryKey pass the `usePrimaryKey` option
         // to ther query.
-        let scores = try await GameScore.query.findAll(options: [.useMasterKey])
+        let scores = try await GameScore.query.findAll(options: [.usePrimaryKey])
         req.logger.info("All scores: \(scores)")
         return ParseHookResponse(success: object)
     }


### PR DESCRIPTION
- [x] Switch to `primaryKey` from `masterKey` due to insensitive language
- [x] Update to netreconlab `ParseSwift`
- [x] Update to latest version of `vapor`  