### PR TITLE
fix: Always register routes on event loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Use multiple cores
       run: defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
     - name: Build and Test
-      run: swift test --enable-code-coverage -v
+      run: swift test --enable-code-coverage
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE }}
     - name: Prepare codecov
@@ -55,7 +55,7 @@ jobs:
           release-version: "5"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
-        run: swift test --enable-test-discovery --enable-code-coverage -v
+        run: swift test --enable-test-discovery --enable-code-coverage
       - name: Update codecov config
         run: cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
       - name: Prepare codecov

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "cbfed65c3bd305bbb6c0f6358201d912a94d968e",
-          "version": "5.0.0-beta.4"
+          "revision": "de696cc10142a0a75186ba83a04bdd62668b31d1",
+          "version": "5.0.0-beta.5"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "de696cc10142a0a75186ba83a04bdd62668b31d1",
-          "version": "5.0.0-beta.5"
+          "revision": "2494b3f65d45ffd9619d4f68a4790ac3d6e95f19",
+          "version": "5.0.0-beta.6"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -4,17 +4,20 @@ import PackageDescription
 let package = Package(
     name: "ParseServerSwift",
     platforms: [
-       .macOS(.v12)
+        .iOS(.v13),
+        .macCatalyst(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
             .library(name: "ParseServerSwift", targets: ["ParseServerSwift"])
     ],
     dependencies: [
-        // 💧 A server-side Swift web framework.
         .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.69.1")),
         .package(url: "https://github.com/vapor/leaf.git", .upToNextMajor(from: "4.2.4")),
         .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-                 .upToNextMajor(from: "5.0.0-beta.5")),
+                 .upToNextMajor(from: "5.0.0-beta.6")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.69.1")),
         .package(url: "https://github.com/vapor/leaf.git", .upToNextMajor(from: "4.2.4")),
         .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-                 .upToNextMajor(from: "5.0.0-beta.4")),
+                 .upToNextMajor(from: "5.0.0-beta.5")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Technically, complete apps can be written with `ParseServerSwift`, the only diff
 The following enviroment variables are available and can be configured directly or through `.env`, `.env.production`, etc. See the [Vapor Docs for more details](https://docs.vapor.codes/basics/environment/).
 
 ```
-PARSE_SWIFT_SERVER_HOST_NAME: cloud-code # The name of your host. If you are running in Docker it should be same name as the docker service
-PARSE_SWIFT_SERVER_PORT: # This is the default port on the docker image
-PARSE_SWIFT_SERVER_DEFAULT_MAX_BODY_SIZE: 500kb # Set the default size for bodies that are collected into memory before calling your handlers (See Vapor docs for more details)
-PARSE_SWIFT_SERVER_URLS: http://parse:1337/parse # (Required) Specify one of your Parse Servers to connect to. Can connect to multiple by seperating URLs with commas
-PARSE_SWIFT_SERVER_APPLICATION_ID: appId # (Required) The application id of your Parse Server
-PARSE_SWIFT_SERVER_PRIMARY_KEY: primaryKey # (Required) The master key of your Parse Server 
-PARSE_SWIFT_SERVER_WEBHOOK_KEY: webookKey # The webhookKey of your Parse Server
+PARSE_SERVER_SWIFT_HOST_NAME: cloud-code # The name of your host. If you are running in Docker it should be same name as the docker service
+PARSE_SERVER_SWIFT_PORT: # This is the default port on the docker image
+PARSE_SERVER_SWIFT_DEFAULT_MAX_BODY_SIZE: 500kb # Set the default size for bodies that are collected into memory before calling your handlers (See Vapor docs for more details)
+PARSE_SERVER_SWIFT_URLS: http://parse:1337/parse # (Required) Specify one of your Parse Servers to connect to. Can connect to multiple by seperating URLs with commas
+PARSE_SERVER_SWIFT_APPLICATION_ID: appId # (Required) The application id of your Parse Server
+PARSE_SERVER_SWIFT_PRIMARY_KEY: primaryKey # (Required) The master key of your Parse Server 
+PARSE_SERVER_SWIFT_WEBHOOK_KEY: webookKey # The webhookKey of your Parse Server
 ```
 
 If you need to customize your configuration you will need to edit [ParseServerSwift/Sources/ParseServerSwift/configure.swift](https://github.com/netreconlab/ParseServerSwift/blob/main/Sources/ParseServerSwift/configure.swift) directly.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Cloud Code Functions can also take parameters. It's recommended to place all par
 [ParseServerSwift/Sources/ParseServerSwift/Models/Parameters](https://github.com/netreconlab/ParseServerSwift/blob/main/Sources/ParseServerSwift/Models/Parameters)
 
 ```swift
+// A Parse Hook Function route.
 app.post("hello",
          name: "hello") { req async throws -> ParseHookResponse<String> in
     if let error: ParseHookResponse<String> = checkHeaders(req) {
@@ -133,13 +134,13 @@ app.post("hello",
 ```swift
 // A Parse Hook Trigger route.
 app.post("score", "save", "before",
-         className: "GameScore",
+         className: GameScore.className,
          triggerName: .beforeSave) { req async throws -> ParseHookResponse<GameScore> in
     if let error: ParseHookResponse<GameScore> = checkHeaders(req) {
         return error
     }
     var parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
     // If a User called the request, fetch the complete user.
     if parseRequest.user != nil {
@@ -148,45 +149,49 @@ app.post("score", "save", "before",
 
     guard let object = parseRequest.object else {
         return ParseHookResponse(error: .init(code: .missingObjectId,
-                                                message: "Object not sent in request."))
+                                              message: "Object not sent in request."))
     }
     // To query using the primaryKey pass the `usePrimaryKey` option
     // to ther query.
     let scores = try await GameScore.query.findAll(options: [.usePrimaryKey])
-    req.logger.info("All scores: \(scores)")
+    req.logger.info("Before save is being made. Showing all scores before saving new ones: \(scores)")
     return ParseHookResponse(success: object)
 }
 
 // Another Parse Hook Trigger route.
 app.post("score", "find", "before",
-         className: "GameScore",
+         className: GameScore.className,
          triggerName: .beforeFind) { req async throws -> ParseHookResponse<[GameScore]> in
     if let error: ParseHookResponse<[GameScore]> = checkHeaders(req) {
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
     req.logger.info("A query is being made: \(parseRequest)")
 
     // Return two custom scores instead.
     let score1 = GameScore(objectId: "yolo",
-                            createdAt: Date(),
-                            points: 50)
+                           createdAt: Date(),
+                           points: 50)
     let score2 = GameScore(objectId: "nolo",
-                            createdAt: Date(),
-                            points: 60)
+                           createdAt: Date(),
+                           points: 60)
+    req.logger.info("""
+        Returning custom objects to the user from Cloud Code instead of querying:
+        \(score1); \(score2)
+    """)
     return ParseHookResponse(success: [score1, score2])
 }
 
 // Another Parse Hook Trigger route.
 app.post("user", "login", "after",
-         className: "_User",
+         className: User.className,
          triggerName: .afterLogin) { req async throws -> ParseHookResponse<Bool> in
     if let error: ParseHookResponse<Bool> = checkHeaders(req) {
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
     req.logger.info("A user has logged in: \(parseRequest)")
     return ParseHookResponse(success: true)
@@ -199,7 +204,7 @@ app.on("file", "save", "before",
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerRequest<User>.self)
 
     req.logger.info("A ParseFile is being saved: \(parseRequest)")
     return ParseHookResponse(success: true)
@@ -212,7 +217,7 @@ app.post("file", "delete", "before",
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerRequest<User>.self)
 
     req.logger.info("A ParseFile is being deleted: \(parseRequest)")
     return ParseHookResponse(success: true)
@@ -225,7 +230,7 @@ app.post("connect", "before",
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerRequest<User>.self)
 
     req.logger.info("A LiveQuery connection is being made: \(parseRequest)")
     return ParseHookResponse(success: true)
@@ -233,27 +238,27 @@ app.post("connect", "before",
 
 // Another Parse Hook Trigger route for `ParseLiveQuery`.
 app.post("score", "subscribe", "before",
-         className: "GameScore",
+         className: GameScore.className,
          triggerName: .beforeSubscribe) { req async throws -> ParseHookResponse<Bool> in
     if let error: ParseHookResponse<Bool> = checkHeaders(req) {
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
-    req.logger.info("A LiveQuery subscribe is being made: \(parseRequest)")
+    req.logger.info("A LiveQuery subscription is being made: \(parseRequest)")
     return ParseHookResponse(success: true)
 }
 
 // Another Parse Hook Trigger route for `ParseLiveQuery`.
 app.post("score", "event", "after",
-         className: "GameScore",
+         className: GameScore.className,
          triggerName: .afterEvent) { req async throws -> ParseHookResponse<Bool> in
     if let error: ParseHookResponse<Bool> = checkHeaders(req) {
         return error
     }
     let parseRequest = try req.content
-        .decode(ParseHookTriggerRequest<User, GameScore>.self)
+        .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
     req.logger.info("A LiveQuery event occured: \(parseRequest)")
     return ParseHookResponse(success: true)

--- a/README.md
+++ b/README.md
@@ -192,9 +192,8 @@ app.post("user", "login", "after",
     return ParseHookResponse(success: true)
 }
 
-// A Parse Hook Trigger route for `ParseFile` where the body will not be collected into a buffer.
+// A Parse Hook Trigger route for `ParseFile`.
 app.on("file", "save", "before",
-       body: .stream,
        triggerName: .beforeSave) { req async throws -> ParseHookResponse<Bool> in
     if let error: ParseHookResponse<Bool> = checkHeaders(req) {
         return error

--- a/Sources/ParseServerSwift/Utility/Functions.swift
+++ b/Sources/ParseServerSwift/Utility/Functions.swift
@@ -98,7 +98,7 @@ public func deleteHooks(_ app: Application) async {
 }
 
 func getParseServerURLs(_ urls: String? = nil) throws -> (String, [String]) {
-    let serverURLs = urls ?? Environment.process.PARSE_SWIFT_SERVER_URLS ?? "http://localhost:1337/parse"
+    let serverURLs = urls ?? Environment.process.PARSE_SERVER_SWIFT_URLS ?? "http://localhost:1337/parse"
     var allServers = serverURLs.replacingOccurrences(of: " ", with: "").split(separator: ",").compactMap { String($0) }
     guard let mainServer = allServers.popLast() else {
         throw ParseError(code: .otherCause, message: "At least 1 server URL is required")

--- a/Sources/ParseServerSwift/routes.swift
+++ b/Sources/ParseServerSwift/routes.swift
@@ -96,9 +96,8 @@ func routes(_ app: Application) throws {
         return ParseHookResponse(success: true)
     }
 
-    // A Parse Hook Trigger route for `ParseFile` where the body will not be collected into a buffer.
+    // A Parse Hook Trigger route for `ParseFile`.
     app.on("file", "save", "before",
-           body: .stream,
            triggerName: .beforeSave) { req async throws -> ParseHookResponse<Bool> in
         if let error: ParseHookResponse<Bool> = checkHeaders(req) {
             return error

--- a/Sources/ParseServerSwift/routes.swift
+++ b/Sources/ParseServerSwift/routes.swift
@@ -37,13 +37,13 @@ func routes(_ app: Application) throws {
 
     // A Parse Hook Trigger route.
     app.post("score", "save", "before",
-             className: "GameScore",
+             className: GameScore.className,
              triggerName: .beforeSave) { req async throws -> ParseHookResponse<GameScore> in
         if let error: ParseHookResponse<GameScore> = checkHeaders(req) {
             return error
         }
         var parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
         // If a User called the request, fetch the complete user.
         if parseRequest.user != nil {
@@ -57,21 +57,21 @@ func routes(_ app: Application) throws {
         // To query using the primaryKey pass the `usePrimaryKey` option
         // to ther query.
         let scores = try await GameScore.query.findAll(options: [.usePrimaryKey])
-        req.logger.info("All scores: \(scores)")
+        req.logger.info("Before save is being made. Showing all scores before saving new ones: \(scores)")
         return ParseHookResponse(success: object)
     }
 
     // Another Parse Hook Trigger route.
     app.post("score", "find", "before",
-             className: "GameScore",
+             className: GameScore.className,
              triggerName: .beforeFind) { req async throws -> ParseHookResponse<[GameScore]> in
         if let error: ParseHookResponse<[GameScore]> = checkHeaders(req) {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
         req.logger.info("A query is being made: \(parseRequest)")
-        
+
         // Return two custom scores instead.
         let score1 = GameScore(objectId: "yolo",
                                createdAt: Date(),
@@ -79,18 +79,22 @@ func routes(_ app: Application) throws {
         let score2 = GameScore(objectId: "nolo",
                                createdAt: Date(),
                                points: 60)
+        req.logger.info("""
+            Returning custom objects to the user from Cloud Code instead of querying:
+            \(score1); \(score2)
+        """)
         return ParseHookResponse(success: [score1, score2])
     }
 
     // Another Parse Hook Trigger route.
     app.post("user", "login", "after",
-             className: "_User",
+             className: User.className,
              triggerName: .afterLogin) { req async throws -> ParseHookResponse<Bool> in
         if let error: ParseHookResponse<Bool> = checkHeaders(req) {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
         req.logger.info("A user has logged in: \(parseRequest)")
         return ParseHookResponse(success: true)
@@ -103,7 +107,7 @@ func routes(_ app: Application) throws {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerRequest<User>.self)
 
         req.logger.info("A ParseFile is being saved: \(parseRequest)")
         return ParseHookResponse(success: true)
@@ -116,7 +120,7 @@ func routes(_ app: Application) throws {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerRequest<User>.self)
 
         req.logger.info("A ParseFile is being deleted: \(parseRequest)")
         return ParseHookResponse(success: true)
@@ -129,7 +133,7 @@ func routes(_ app: Application) throws {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerRequest<User>.self)
 
         req.logger.info("A LiveQuery connection is being made: \(parseRequest)")
         return ParseHookResponse(success: true)
@@ -137,13 +141,13 @@ func routes(_ app: Application) throws {
 
     // Another Parse Hook Trigger route for `ParseLiveQuery`.
     app.post("score", "subscribe", "before",
-             className: "GameScore",
+             className: GameScore.className,
              triggerName: .beforeSubscribe) { req async throws -> ParseHookResponse<Bool> in
         if let error: ParseHookResponse<Bool> = checkHeaders(req) {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
         req.logger.info("A LiveQuery subscription is being made: \(parseRequest)")
         return ParseHookResponse(success: true)
@@ -151,13 +155,13 @@ func routes(_ app: Application) throws {
 
     // Another Parse Hook Trigger route for `ParseLiveQuery`.
     app.post("score", "event", "after",
-             className: "GameScore",
+             className: GameScore.className,
              triggerName: .afterEvent) { req async throws -> ParseHookResponse<Bool> in
         if let error: ParseHookResponse<Bool> = checkHeaders(req) {
             return error
         }
         let parseRequest = try req.content
-            .decode(ParseHookTriggerRequest<User, GameScore>.self)
+            .decode(ParseHookTriggerObjectRequest<User, GameScore>.self)
 
         req.logger.info("A LiveQuery event occured: \(parseRequest)")
         return ParseHookResponse(success: true)

--- a/Tests/ParseServerSwiftTests/AppTests.swift
+++ b/Tests/ParseServerSwiftTests/AppTests.swift
@@ -11,8 +11,8 @@ final class AppTests: XCTestCase {
 
     func setupAppForTesting(hookKey: String? = nil) throws -> Application {
         let app = Application(.testing)
-        webhookKey = hookKey
         try configure(app, testing: true)
+        webhookKey = hookKey
         Parse.configuration.isTestingSDK = true
         return app
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ x-shared_environment: &shared_environment
   PARSE_SERVER_MOUNT_GRAPHQL: 'false'
   PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'true' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
   PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
-  PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true' # When this is true, only need one server for PARSE_SWIFT_SERVER_URLS 
+  PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true' # When this is true, only need one server for PARSE_SERVER_SWIFT_URLS 
   PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
   PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
   PARSE_SERVER_USING_PARSECAREKIT: 'false' # If you are not using ParseCareKit, set this to 'false'
@@ -52,13 +52,13 @@ services:
       context: .
     environment:
       <<: *shared_environment
-      PARSE_SWIFT_SERVER_HOST_NAME: cloud-code # Should be same name as docker service
-      PARSE_SWIFT_SERVER_PORT: 8081
-      PARSE_SWIFT_SERVER_DEFAULT_MAX_BODY_SIZE: 500kb
-      PARSE_SWIFT_SERVER_URLS: http://parse:1337/parse #,http://parse2:1337/parse # Only need to list one server when PARSE_SERVER_ENABLE_SCHEMA_HOOKS='true' 
-      PARSE_SWIFT_SERVER_APPLICATION_ID: ${PARSE_SERVER_APPLICATION_ID}
-      PARSE_SWIFT_SERVER_PRIMARY_KEY: ${PARSE_SERVER_PRIMARY_KEY}
-      PARSE_SWIFT_SERVER_WEBHOOK_KEY: ${PARSE_SERVER_WEBHOOK_KEY}
+      PARSE_SERVER_SWIFT_HOST_NAME: cloud-code # Should be same name as docker service
+      PARSE_SERVER_SWIFT_PORT: 8081
+      PARSE_SERVER_SWIFT_DEFAULT_MAX_BODY_SIZE: 500kb
+      PARSE_SERVER_SWIFT_URLS: http://parse:1337/parse #,http://parse2:1337/parse # Only need to list one server when PARSE_SERVER_ENABLE_SCHEMA_HOOKS='true' 
+      PARSE_SERVER_SWIFT_APPLICATION_ID: ${PARSE_SERVER_APPLICATION_ID}
+      PARSE_SERVER_SWIFT_PRIMARY_KEY: ${PARSE_SERVER_PRIMARY_KEY}
+      PARSE_SERVER_SWIFT_WEBHOOK_KEY: ${PARSE_SERVER_WEBHOOK_KEY}
     # ports:
     #  - '8081:8081'
     # user: '0' # uncomment to run as root for testing purposes even though Dockerfile defines 'vapor' user.

--- a/parse/index.js
+++ b/parse/index.js
@@ -68,7 +68,7 @@ const objectIdSize = parseInt(process.env.PARSE_SERVER_OBJECT_ID_SIZE) || 10;
 const sessionLength = parseInt(process.env.PARSE_SERVER_SESSION_LENGTH) || 31536000;
 const emailVerifyTokenValidityDuration = parseInt(process.env.PARSE_SERVER_EMAIL_VERIFY_TOKEN_VALIDITY_DURATION) || 24*60*60;
 const accountLockoutDuration = parseInt(process.env.PARSE_SERVER_ACCOUNT_LOCKOUT_DURATION) || 5;
-const accountLockoutThreshold = parseInt(process.env.PARSE_SERVER_ACCOUNT_LOCKOUT_THRESHOLD) || 3;
+const accountLockoutThreshold = parseInt(process.env.PARSE_SERVER_ACCOUNT_LOCKOUT_THRESHOLD) || 5;
 const maxPasswordHistory = parseInt(process.env.PARSE_SERVER_PASSWORD_POLICY_MAX_PASSWORD_HISTORY) || 5;
 const resetTokenValidityDuration = parseInt(process.env.PARSE_SERVER_PASSWORD_POLICY_RESET_TOKEN_VALIDITY_DURATION) || 24*60*60;
 const validationError = process.env.PARSE_SERVER_PASSWORD_POLICY_VALIDATION_ERROR || 'Password must have at least 8 characters, contain at least 1 digit, 1 lower case, 1 upper case, and contain at least one special character.';
@@ -253,6 +253,7 @@ configuration = {
   appId: applicationId,
   masterKey: primaryKey,
   masterKeyIps: primaryKeyIPs,
+  webhookKey: process.env.PARSE_SERVER_WEBHOOK_KEY,
   encryptionKey: process.env.PARSE_SERVER_ENCRYPTION_KEY,
   objectIdSize: objectIdSize,
   serverURL: serverURL,


### PR DESCRIPTION
- [x] Fix issue where routes wouldn't run properly because they were in async/await task
- [x] Update to latest Parse-Swift 5.0.0.beta.5 to decode `ParseFile` properly 
- [x] Change environment variables
- [x] Add `webhookKey` to parse-hipaa server index file 
- [x] Fix some bugs inside of routes  