### PR TITLE
fix: Use deleteHooks() method when shutting down

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: 48
+        target: 46
     changes: false
     project:
       default:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Use multiple cores
       run: defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
+    - name: Lint
+      run: set -o pipefail && env NSUnbufferedIO=YES swiftlint --strict
     - name: Build and Test
-      run: swift test --enable-code-coverage
+      run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage | xcpretty -c
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE }}
     - name: Prepare codecov
@@ -51,7 +53,7 @@ jobs:
           release-version: "5.7"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
-        run: swift test --enable-test-discovery --enable-code-coverage
+        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
       - name: Update codecov config
         run: cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
       - name: Prepare codecov

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - identifier_name
+  - blanket_disable_command
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - DerivedData
+  - .build
+  - .dependencies

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/Parse-Swift.git",
       "state" : {
-        "revision" : "0902da8b34cd11d6ba69e04d208d5a8505f0be9d",
-        "version" : "5.6.0"
+        "revision" : "8ae529657e32d4b65c8c429dc5296ab865c4721d",
+        "version" : "5.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.76.2")),
         .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-                 .upToNextMajor(from: "5.6.0"))
+                 .upToNextMajor(from: "5.7.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,8 @@
 // swift-tools-version:5.6
 import PackageDescription
 
+// swiftlint:disable line_length
+
 let package = Package(
     name: "ParseServerSwift",
     platforms: [
@@ -16,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.76.2")),
         .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-                 .upToNextMajor(from: "5.6.0")),
+                 .upToNextMajor(from: "5.6.0"))
     ],
     targets: [
         .target(
@@ -35,7 +37,7 @@ let package = Package(
                           ]),
         .testTarget(name: "ParseServerSwiftTests", dependencies: [
             .target(name: "ParseServerSwift"),
-            .product(name: "XCTVapor", package: "vapor"),
+            .product(name: "XCTVapor", package: "vapor")
         ])
     ]
 )

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -42,7 +42,7 @@ enum Entrypoint {
             }
         }
 
-        try await configure(app)
+        try await parseServerSwiftConfigure(app)
         try await app.runFromAsyncMainEntrypoint()
     }
 }

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -35,11 +35,14 @@ enum Entrypoint {
         try LoggingSystem.bootstrap(from: &env)
 
         let app = Application(env)
+
         defer {
             Task {
+                // This may not delete all because it's async
+                // Be sure to delete manually in dashboard
                 await deleteHooks(app)
-                app.shutdown()
             }
+            app.shutdown()
         }
 
         try await parseServerSwiftConfigure(app)

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -35,7 +35,12 @@ enum Entrypoint {
         try LoggingSystem.bootstrap(from: &env)
         
         let app = Application(env)
-        defer { app.shutdown() }
+        defer {
+            Task {
+                await deleteHooks(app)
+                app.shutdown()
+            }
+        }
         
         try await configure(app)
         try await app.runFromAsyncMainEntrypoint()

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -13,7 +13,7 @@ import ParseServerSwift
 /// This extension is temporary and can be removed once Vapor gets this support.
 private extension Vapor.Application {
     static let baseExecutionQueue = DispatchQueue(label: "vapor.codes.entrypoint")
-    
+
     func runFromAsyncMainEntrypoint() async throws {
         try await withCheckedThrowingContinuation { continuation in
             Vapor.Application.baseExecutionQueue.async { [self] in
@@ -33,7 +33,7 @@ enum Entrypoint {
     static func main() async throws {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
-        
+
         let app = Application(env)
         defer {
             Task {
@@ -41,7 +41,7 @@ enum Entrypoint {
                 app.shutdown()
             }
         }
-        
+
         try await configure(app)
         try await app.runFromAsyncMainEntrypoint()
     }

--- a/Sources/ParseServerSwift/Extensions/Parse+Vapor.swift
+++ b/Sources/ParseServerSwift/Extensions/Parse+Vapor.swift
@@ -23,6 +23,7 @@ public extension ParseHookRequestable {
      In a single Parse Server environment, use options().
      */
     func options(_ request: Request,
+                 // swiftlint:disable:next line_length
                  parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) throws -> API.Options {
         var options = self.options()
         options.insert(.serverURL(try serverURLString(request.url,
@@ -43,6 +44,7 @@ public extension ParseHookRequestable {
      */
      func hydrateUser(options: API.Options = [],
                       request: Request,
+                      // swiftlint:disable:next line_length
                       parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> Self {
          var updatedOptions = try self.options(request, parseServerURLStrings: parseServerURLStrings)
          updatedOptions = updatedOptions.union(options)

--- a/Sources/ParseServerSwift/Models/HookFunction.swift
+++ b/Sources/ParseServerSwift/Models/HookFunction.swift
@@ -50,13 +50,17 @@ extension HookFunction {
                         .delete(options: [.serverURL(parseServerURLString)])
                 default:
                     throw ParseError(code: .otherCause,
+                                     // swiftlint:disable:next line_length
                                      message: "Method \(method) is not supported for Hook Function: \"\(String(describing: hookFunction))\"")
                 }
+                // swiftlint:disable:next line_length
                 configuration.logger.notice("Successful \(method); Hook Function: \"\(String(describing: hookFunction))\" on server: \(parseServerURLString)")
             } catch {
                 if error.containedIn([.webhookError]) && method == .POST {
+                    // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Function: \"\(String(describing: hookFunction))\"; warning: \(error); on server: \(parseServerURLString)")
                 } else {
+                    // swiftlint:disable:next line_length
                     configuration.logger.error("Could not \(method) Hook Function: \"\(String(describing: hookFunction))\"; error: \(error); on server: \(parseServerURLString)")
                 }
             }
@@ -68,7 +72,7 @@ extension HookFunction {
 
 // MARK: HookFunction - Fetch
 public extension HookFunction {
-    
+
     /**
      Fetches a Parse Cloud Code hook function.
      - parameter path: A variadic list of paths.
@@ -80,8 +84,8 @@ public extension HookFunction {
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func fetch(_ path: PathComponent...,
-                       name: String,
-                       parseServerURLStrings: [String]) async throws -> [String: HookFunction] {
+                      name: String,
+                      parseServerURLStrings: [String]) async throws -> [String: HookFunction] {
         try await fetch(path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
 
@@ -96,11 +100,11 @@ public extension HookFunction {
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func fetch(_ path: [PathComponent],
-                       name: String,
-                       parseServerURLStrings: [String]) async throws -> [String: HookFunction] {
+                      name: String,
+                      parseServerURLStrings: [String]) async throws -> [String: HookFunction] {
         try await method(.PUT, path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
-    
+
     /**
      Fetches all Parse Cloud Code hook function.
      - parameter path: A variadic list of paths.
@@ -140,6 +144,7 @@ public extension HookFunction {
                 hookFunctions[parseServerURLString] = try await hookFunction
                     .fetchAll(options: [.serverURL(parseServerURLString)])
             } catch {
+                // swiftlint:disable:next line_length
                 configuration.logger.error("Could not fetchAll function: \"\(String(describing: hookFunction))\"; error: \(error); on server: \(parseServerURLString)")
             }
         }
@@ -149,7 +154,7 @@ public extension HookFunction {
 
 // MARK: HookFunction - Create
 public extension HookFunction {
-    
+
     /**
      Creates a Parse Cloud Code hook function.
      - parameter path: A variadic list of paths.
@@ -163,6 +168,7 @@ public extension HookFunction {
      */
     static func create(_ path: PathComponent...,
                        name: String,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: HookFunction] {
         try await create(path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
@@ -180,6 +186,7 @@ public extension HookFunction {
      */
     static func create(_ path: [PathComponent],
                        name: String,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: HookFunction] {
         try await method(.POST, path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
@@ -187,7 +194,7 @@ public extension HookFunction {
 
 // MARK: HookFunction - Update
 public extension HookFunction {
-    
+
     /**
      Updates a Parse Cloud Code hook function.
      - parameter path: A variadic list of paths.
@@ -201,6 +208,7 @@ public extension HookFunction {
      */
     static func update(_ path: PathComponent...,
                        name: String,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: HookFunction] {
         try await update(path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
@@ -218,6 +226,7 @@ public extension HookFunction {
      */
     static func update(_ path: [PathComponent],
                        name: String,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: HookFunction] {
         try await method(.PUT, path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
@@ -225,7 +234,7 @@ public extension HookFunction {
 
 // MARK: HookFunction - Delete
 public extension HookFunction {
-    
+
     /**
      Removes a Parse Cloud Code hook function.
      - parameter path: A variadic list of paths.
@@ -238,6 +247,7 @@ public extension HookFunction {
      */
     static func delete(_ path: PathComponent...,
                        name: String,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws {
         try await delete(path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
@@ -254,6 +264,7 @@ public extension HookFunction {
      */
     static func delete(_ path: [PathComponent],
                        name: String,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws {
         try await method(.DELETE, path, name: name, parseServerURLStrings: parseServerURLStrings)
     }
@@ -276,8 +287,7 @@ public extension RoutesBuilder {
         name: String,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         self.on(path,
                 name: name,
                 use: closure)
@@ -298,8 +308,7 @@ public extension RoutesBuilder {
         name: String,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         self.on(path,
                 name: name,
                 use: closure)
@@ -322,8 +331,7 @@ public extension RoutesBuilder {
         name: String,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         self.on(path,
                 body: body,
                 name: name,
@@ -347,13 +355,13 @@ public extension RoutesBuilder {
         name: String,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         Task {
             do {
                 await configuration.hooks.updateFunctions(try await HookFunction.create(path,
                                                                                         name: name))
             } catch {
+                // swiftlint:disable:next line_length
                 configuration.logger.error("Could not create HookFunction route for path: \(path); name: \(name) on servers: \(configuration.parseServerURLStrings) because of error: \(error)")
             }
         }

--- a/Sources/ParseServerSwift/Models/HookTrigger.swift
+++ b/Sources/ParseServerSwift/Models/HookTrigger.swift
@@ -33,7 +33,7 @@ extension HookTrigger {
         let url = try buildServerPathname(path)
         let hookTrigger: HookTrigger!
         var hookTriggers = [String: Self]()
-        
+
         if let className = className {
             hookTrigger = HookTrigger(className: className,
                                       triggerName: triggerName,
@@ -50,6 +50,7 @@ extension HookTrigger {
                     hookTriggers[parseServerURLString] = try await hookTrigger
                         .fetch(options: [.serverURL(parseServerURLString)])
                 case .POST:
+                    // swiftlint:disable:next line_length
                     hookTriggers[parseServerURLString] = try await hookTrigger.create(options: [.serverURL(parseServerURLString)])
                 case .PUT:
                     hookTriggers[parseServerURLString] = try await hookTrigger
@@ -59,13 +60,17 @@ extension HookTrigger {
                         .delete(options: [.serverURL(parseServerURLString)])
                 default:
                     throw ParseError(code: .otherCause,
+                                     // swiftlint:disable:next line_length
                                      message: "Method \(method) is not supported for Hook Trigger: \"\(String(describing: hookTrigger))\"")
                 }
+                // swiftlint:disable:next line_length
                 configuration.logger.notice("Successful \(method); Hook Trigger: \"\(String(describing: hookTrigger))\" on server: \(parseServerURLString)")
             } catch {
                 if error.containedIn([.webhookError]) && method == .POST {
+                    // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Trigger: \"\(String(describing: hookTrigger))\"; warning: \(error); on server: \(parseServerURLString)")
                 } else {
+                    // swiftlint:disable:next line_length
                     configuration.logger.error("Could not \(method) Hook Trigger: \"\(String(describing: hookTrigger))\"; error: \(error); on server: \(parseServerURLString)")
                 }
             }
@@ -85,13 +90,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func fetch(_ path: PathComponent...,
                       className: String? = nil,
                       triggerName: ParseHookTriggerType,
+                      // swiftlint:disable:next line_length
                       parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: Self] {
         try await fetch(path,
                         className: className,
@@ -108,13 +115,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func fetch(_ path: [PathComponent],
                       className: String? = nil,
                       triggerName: ParseHookTriggerType,
+                      // swiftlint:disable:next line_length
                       parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: Self] {
         try await method(.GET,
                          path,
@@ -132,13 +141,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`'s.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func fetchAll(_ path: PathComponent...,
                          className: String? = nil,
                          triggerName: ParseHookTriggerType,
+                         // swiftlint:disable:next line_length
                          parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: [Self]] {
         try await fetchAll(path,
                            className: className,
@@ -155,18 +166,20 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`'s.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func fetchAll(_ path: [PathComponent],
                          className: String? = nil,
                          triggerName: ParseHookTriggerType,
+                         // swiftlint:disable:next line_length
                          parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: [Self]] {
         let url = try buildServerPathname(path)
         let hookTrigger: HookTrigger!
         var hookTriggers = [String: [Self]]()
-        
+
         if let className = className {
             hookTrigger = Self(className: className,
                                triggerName: triggerName,
@@ -180,6 +193,7 @@ public extension HookTrigger {
                 hookTriggers[parseServerURLString] = try await hookTrigger
                     .fetchAll(options: [.serverURL(parseServerURLString)])
             } catch {
+                // swiftlint:disable:next line_length
                 configuration.logger.error("Problem fetching all triggers: \"\(String(describing: hookTrigger))\"; error: \(error); on server: \(parseServerURLString)")
             }
         }
@@ -189,7 +203,7 @@ public extension HookTrigger {
 
 // MARK: HookTrigger - Create
 public extension HookTrigger {
-    
+
     /**
      Create a Parse Cloud Code hook trigger.
      - parameter path: A variadic list of paths.
@@ -199,13 +213,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func create(_ path: PathComponent...,
                        className: String? = nil,
                        triggerName: ParseHookTriggerType,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: Self] {
         try await create(path,
                          className: className,
@@ -222,13 +238,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func create(_ path: [PathComponent],
                        className: String? = nil,
                        triggerName: ParseHookTriggerType,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: Self] {
         try await method(.POST,
                          path,
@@ -249,13 +267,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func update(_ path: PathComponent...,
                        className: String? = nil,
                        triggerName: ParseHookTriggerType,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: Self] {
         try await update(path,
                          className: className,
@@ -272,13 +292,15 @@ public extension HookTrigger {
      Defaults to the set of servers added during configuration.
      - returns: A dictionary where the keys are Parse Server `URL`'s and the respective `HookTrigger`.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func update(_ path: [PathComponent],
                        className: String? = nil,
                        triggerName: ParseHookTriggerType,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws -> [String: Self] {
         try await method(.PUT,
                          path,
@@ -290,7 +312,7 @@ public extension HookTrigger {
 
 // MARK: HookTrigger - Delete
 public extension HookTrigger {
-    
+
     /**
      Delete a Parse Cloud Code hook trigger.
      - parameter path: A variadic list of paths.
@@ -299,13 +321,15 @@ public extension HookTrigger {
      - parameter parseServerURLStrings: A set of Parse Server `URL`'s to delete triggers for.
      Defaults to the set of servers added during configuration.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func delete(_ path: PathComponent...,
                        className: String? = nil,
                        triggerName: ParseHookTriggerType,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws {
         try await delete(path,
                          className: className,
@@ -321,13 +345,15 @@ public extension HookTrigger {
      - parameter parseServerURLStrings: A set of Parse Server `URL`'s to delete triggers for.
      Defaults to the set of servers added during configuration.
      - throws: An error of `ParseError` type.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
     static func delete(_ path: [PathComponent],
                        className: String? = nil,
                        triggerName: ParseHookTriggerType,
+                       // swiftlint:disable:next line_length
                        parseServerURLStrings: [String] = ParseServerSwift.configuration.parseServerURLStrings) async throws {
         try await method(.DELETE,
                          path,
@@ -346,7 +372,8 @@ public extension RoutesBuilder {
      - parameter triggerName: The `ParseHookTriggerType` type.
      - parameter parseServerURLStrings: A set of Parse Server `URL`'s to create triggers for.
      - parameter hooks: An actor containing all of the current Hooks.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
@@ -357,8 +384,7 @@ public extension RoutesBuilder {
         triggerName: ParseHookTriggerType,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         self.on(path,
                 className: className,
                 triggerName: triggerName,
@@ -373,7 +399,8 @@ public extension RoutesBuilder {
      - parameter triggerName: The `ParseHookTriggerType` type.
      - parameter parseServerURLStrings: A set of Parse Server `URL`'s to create triggers for.
      - parameter hooks: An actor containing all of the current Hooks.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
@@ -384,8 +411,7 @@ public extension RoutesBuilder {
         triggerName: ParseHookTriggerType,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         self.on(path,
                 className: className,
                 triggerName: triggerName,
@@ -400,7 +426,8 @@ public extension RoutesBuilder {
      - parameter triggerName: The `ParseHookTriggerType` type.
      - parameter parseServerURLStrings: A set of Parse Server `URL`'s to create triggers for.
      - parameter hooks: An actor containing all of the current Hooks.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
@@ -412,8 +439,7 @@ public extension RoutesBuilder {
         triggerName: ParseHookTriggerType,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         self.on(path,
                 body: body,
                 className: className,
@@ -429,7 +455,8 @@ public extension RoutesBuilder {
      - parameter triggerName: The `ParseHookTriggerType` type.
      - parameter parseServerURLStrings: A set of Parse Server `URL`'s to create triggers for.
      - parameter hooks: An actor containing all of the current Hooks.
-     - important: `className` should only be **nil** when creating `ParseFile` and `.beforeConnect` triggers.
+     - important: `className` should only be **nil** when creating `ParseFile` and
+     `.beforeConnect` triggers.
      - note: WIll attempt to create triggers on all `parseServerURLStrings`.
      Will log an error for each `parseServerURLString` that returns an error.
      */
@@ -441,8 +468,7 @@ public extension RoutesBuilder {
         triggerName: ParseHookTriggerType,
         use closure: @escaping (Request) async throws -> Response
     ) -> Route
-        where Response: AsyncResponseEncodable
-    {
+        where Response: AsyncResponseEncodable {
         Task {
             do {
                 await configuration.hooks.updateTriggers(try await HookTrigger.create(path,
@@ -450,8 +476,10 @@ public extension RoutesBuilder {
                                                                                       triggerName: triggerName))
             } catch {
                 if let className = className {
+                    // swiftlint:disable:next line_length
                     configuration.logger.error("Could not create HookTrigger route for path: \(path); className: \(className); triggerName: \(triggerName) on servers: \(configuration.parseServerURLStrings) because of error: \(error)")
                 } else {
+                    // swiftlint:disable:next line_length
                     configuration.logger.error("Could not create HookTrigger route for path: \(path); triggerName: \(triggerName) on servers: \(configuration.parseServerURLStrings) because of error: \(error)")
                 }
             }

--- a/Sources/ParseServerSwift/Parse.swift
+++ b/Sources/ParseServerSwift/Parse.swift
@@ -72,6 +72,7 @@ func initializeServer(_ configuration: ParseServerConfiguration,
             // Check the health of all Parse-Server
             try await checkServerHealth()
         } catch {
+            await deleteHooks(app)
             app.shutdown()
         }
     } else {

--- a/Sources/ParseServerSwift/Parse.swift
+++ b/Sources/ParseServerSwift/Parse.swift
@@ -36,8 +36,8 @@ public func initialize(_ configuration: ParseServerConfiguration,
 }
 
 func initialize(_ configuration: ParseServerConfiguration,
-                       app: Application,
-                       testing: Bool) async throws {
+                app: Application,
+                testing: Bool) async throws {
     var configuration = configuration
     configuration.isTesting = testing
     try await initialize(configuration, app: app)
@@ -49,12 +49,12 @@ func initializeServer(_ configuration: ParseServerConfiguration,
     // Parse uses tailored encoders/decoders. These can be retrieved from any ParseObject
     ContentConfiguration.global.use(encoder: User.getJSONEncoder(), for: .json)
     ContentConfiguration.global.use(decoder: User.getDecoder(), for: .json)
-    
+
     guard let parseServerURL = URL(string: configuration.primaryParseServerURLString) else {
         throw ParseError(code: .otherCause,
                          message: "Could not make a URL from the Parse Server string")
     }
-    
+
     if !configuration.isTesting {
         try setConfiguration(configuration)
         do {

--- a/Sources/ParseServerSwift/ParseServerConfiguration.swift
+++ b/Sources/ParseServerSwift/ParseServerConfiguration.swift
@@ -15,11 +15,12 @@ public struct ParseServerConfiguration {
 
     /// The application id for your Node.js Parse Server application.
     public internal(set) var applicationId: String
-    
+
     /// The primary key for your Node.js Parse Server application.
-    /// - note: This has been renamed from `masterKey` to reflect [inclusive language](https://github.com/dialpad/inclusive-language#motivation).
+    /// - note: This has been renamed from `masterKey` to reflect
+    /// [inclusive language](https://github.com/dialpad/inclusive-language#motivation).
     public internal(set) var primaryKey: String
-    
+
     /// The key used to authenticate incoming webhook calls from a Parse Server.
     public internal(set) var webhookKey: String?
 
@@ -31,7 +32,7 @@ public struct ParseServerConfiguration {
 
     /// The current address of ParseServerSwift.
     public internal(set) var serverPathname: String
-    
+
     var hooks = Hooks()
     var isTesting = false
     var logger = Logger(label: "com.parseserverswift")
@@ -57,8 +58,9 @@ public struct ParseServerConfiguration {
         app.http.server.configuration.hostname = Environment.process.PARSE_SERVER_SWIFT_HOST_NAME ?? "localhost"
         app.http.server.configuration.port = Int(Environment.process.PARSE_SERVER_SWIFT_PORT ?? 8081)
         app.http.server.configuration.tlsConfiguration = tlsConfiguration
+        // swiftlint:disable:next line_length
         app.routes.defaultMaxBodySize = ByteCount(stringLiteral: Environment.process.PARSE_SERVER_SWIFT_DEFAULT_MAX_BODY_SIZE ?? "16kb")
-        
+
         serverPathname = buildServerURL(from: app.http.server.configuration)
         webhookKey = Environment.process.PARSE_SERVER_SWIFT_WEBHOOK_KEY
 
@@ -104,7 +106,7 @@ public struct ParseServerConfiguration {
         app.http.server.configuration.tlsConfiguration = tlsConfiguration
         app.routes.defaultMaxBodySize = maxBodySize
         serverPathname = buildServerURL(from: app.http.server.configuration)
-        
+
         let serverURLStrings = try getParseServerURLs(parseServerURLString)
         primaryParseServerURLString = serverURLStrings.0
         parseServerURLStrings.append(primaryParseServerURLString)
@@ -112,4 +114,3 @@ public struct ParseServerConfiguration {
     }
 
 }
-

--- a/Sources/ParseServerSwift/Utility/Functions.swift
+++ b/Sources/ParseServerSwift/Utility/Functions.swift
@@ -93,14 +93,15 @@ public func checkServerHealth() async throws {
 public func deleteHooks(_ app: Application) async {
     let functions = await configuration.hooks.getFunctions()
     let triggers = await configuration.hooks.getTriggers()
-    
+
     app.logger.notice("Deleting Hooks from all Parse Servers, please wait...")
-    
+
     for (urlString, function) in functions {
         do {
             try await function.delete(options: [.serverURL(urlString)])
             app.logger.notice("Successfully removed Hook Function: \(function); on Parse Server: (\(urlString))")
         } catch {
+            // swiftlint:disable:next line_length
             app.logger.error("Could not remove Hook Function: \(function); on Parse Server: (\(urlString)); due to error: \(error)")
         }
         await configuration.hooks.removeFunctions([urlString])
@@ -111,6 +112,7 @@ public func deleteHooks(_ app: Application) async {
             try await trigger.delete(options: [.serverURL(urlString)])
             app.logger.notice("Successfully removed Hook Trigger: \(trigger); on Parse Server: (\(urlString))")
         } catch {
+            // swiftlint:disable:next line_length
             app.logger.error("Could not remove Hook Trigger: \(trigger); on Parse Server: (\(urlString)); due to error: \(error)")
         }
         await configuration.hooks.removeTriggers([urlString])

--- a/Sources/ParseServerSwift/configure.swift
+++ b/Sources/ParseServerSwift/configure.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-public func configure(_ app: Application) async throws {
+public func parseServerSwiftConfigure(_ app: Application) async throws {
     // Initialize ParseServerSwift
     let configuration = try ParseServerConfiguration(app: app)
     try await ParseServerSwift.initialize(configuration, app: app)

--- a/Sources/ParseServerSwift/configure.swift
+++ b/Sources/ParseServerSwift/configure.swift
@@ -4,7 +4,7 @@ public func configure(_ app: Application) async throws {
     // Initialize ParseServerSwift
     let configuration = try ParseServerConfiguration(app: app)
     try await ParseServerSwift.initialize(configuration, app: app)
-    
+
     // register routes
     try routes(app)
 }

--- a/Sources/ParseServerSwift/routes.swift
+++ b/Sources/ParseServerSwift/routes.swift
@@ -1,6 +1,7 @@
 import Vapor
 import ParseSwift
 
+// swiftlint:disable:next cyclomatic_complexity function_body_length
 func routes(_ app: Application) throws {
 
     // A typical route in Vapor.
@@ -9,7 +10,7 @@ func routes(_ app: Application) throws {
     }
 
     // Another typical route in Vapor.
-    app.get("foo") { req async throws -> String in
+    app.get("foo") { _ async throws -> String in
         return "foo bar"
     }
 
@@ -23,12 +24,12 @@ func routes(_ app: Application) throws {
         }
         var parseRequest = try req.content
             .decode(ParseHookFunctionRequest<User, FooParameters>.self)
-        
+
         // If a User called the request, fetch the complete user.
         if parseRequest.user != nil {
             parseRequest = try await parseRequest.hydrateUser(request: req)
         }
-        
+
         // To query using the User's credentials who called this function,
         // use the options() method from the parseRequest
         let options = try parseRequest.options(req)

--- a/Tests/ParseServerSwiftTests/AppTests.swift
+++ b/Tests/ParseServerSwiftTests/AppTests.swift
@@ -34,13 +34,13 @@ final class AppTests: XCTestCase {
         try routes(app)
         return app
     }
-    
+
     func testConfigRequiresKeys() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         XCTAssertThrowsError(try ParseServerConfiguration(app: app))
     }
-    
+
     func testAllowInitConfigOnce() throws {
         let app = Application(.testing)
         defer { app.shutdown() }

--- a/Tests/ParseServerSwiftTests/AppTests.swift
+++ b/Tests/ParseServerSwiftTests/AppTests.swift
@@ -3,7 +3,7 @@ import ParseSwift
 import XCTVapor
 
 final class AppTests: XCTestCase {
-    
+
     struct DummyRequest: Codable {
         var installationId: String?
         var params: FooParameters
@@ -64,7 +64,7 @@ final class AppTests: XCTestCase {
                                                          parseServerURLString: "primaryKey")
         XCTAssertThrowsError(try setConfiguration(configuration))
     }
-    
+
     func testFooBar() async throws {
         let app = try await setupAppForTesting()
         defer { app.shutdown() }
@@ -137,7 +137,7 @@ final class AppTests: XCTestCase {
     func testFunctionWebhookKeyNotEqual() async throws {
         let app = try await setupAppForTesting(hookKey: "wow")
         defer { app.shutdown() }
-        
+
         try app.test(.POST, "hello", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertTrue(res.body.string.contains("Webhook keys"))
@@ -147,7 +147,7 @@ final class AppTests: XCTestCase {
     func testTriggerWebhookKeyNotEqual() async throws {
         let app = try await setupAppForTesting(hookKey: "wow")
         defer { app.shutdown() }
-        
+
         try app.test(.POST, "score/save/before", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertTrue(res.body.string.contains("Webhook keys"))
@@ -161,12 +161,12 @@ final class AppTests: XCTestCase {
         let uri = URI(stringLiteral: urlString)
         let serverString = try serverURLString(uri, parseServerURLStrings: [urlString])
         XCTAssertEqual(serverString, urlString)
-        
+
         let urlString2 = urlString + "/helloWorld"
         let uri2 = URI(stringLiteral: urlString2)
         let serverString2 = try serverURLString(uri2, parseServerURLStrings: [urlString])
         XCTAssertEqual(serverString2, urlString)
-        
+
         Parse.configuration.parseServerURLStrings = ["http://localhost:1337/parse"]
         let serverString3 = try serverURLString(uri,
                                                 parseServerURLStrings: configuration.parseServerURLStrings)
@@ -213,13 +213,13 @@ final class AppTests: XCTestCase {
     func testHooksFunctions() async throws {
         let functions = await configuration.hooks.getFunctions()
         XCTAssertTrue(functions.isEmpty)
-        
+
         let dummyHooks = ["yo": HookFunction(name: "hello", url: nil),
                           "no": HookFunction(name: "hello", url: nil)]
         await configuration.hooks.updateFunctions(dummyHooks)
         let functions2 = await configuration.hooks.getFunctions()
         XCTAssertEqual(functions2.count, 2)
-        
+
         await configuration.hooks.removeFunctions(["yo"])
         let functions3 = await configuration.hooks.getFunctions()
         XCTAssertNil(functions3["yo"])
@@ -233,7 +233,7 @@ final class AppTests: XCTestCase {
     func testHooksTriggers() async throws {
         let triggers = await configuration.hooks.getTriggers()
         XCTAssertTrue(triggers.isEmpty)
-        
+
         guard let url = URL(string: "http://parse.com") else {
             XCTFail("Should have unwrapped")
             return
@@ -243,7 +243,7 @@ final class AppTests: XCTestCase {
         await configuration.hooks.updateTriggers(dummyHooks)
         let triggers2 = await configuration.hooks.getTriggers()
         XCTAssertEqual(triggers2.count, 2)
-        
+
         await configuration.hooks.removeTriggers(["yo"])
         let triggers3 = await configuration.hooks.getTriggers()
         XCTAssertNil(triggers3["yo"])


### PR DESCRIPTION
- [x] Add example for using deleteHooks
- [x] Lint project
- [x] Update to ParseSwift [5.7.0](https://github.com/netreconlab/Parse-Swift/releases/tag/5.7.0)