### PR TITLE
fix: Existing Hooks are replaced with new ones on restart

### DIFF
--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -37,11 +37,6 @@ enum Entrypoint {
         let app = Application(env)
 
         defer {
-            Task {
-                // This may not delete all because it's async
-                // Be sure to delete manually in dashboard
-                await deleteHooks(app)
-            }
             app.shutdown()
         }
 

--- a/Sources/ParseServerSwift/Models/HookFunction.swift
+++ b/Sources/ParseServerSwift/Models/HookFunction.swift
@@ -59,6 +59,10 @@ extension HookFunction {
                 if error.containedIn([.webhookError]) && method == .POST {
                     // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Function: \"\(String(describing: hookFunction))\"; warning: \(error); on server: \(parseServerURLString)")
+                    try await Self.method(.DELETE,
+                                          path,
+                                          name: name,
+                                          parseServerURLStrings: parseServerURLStrings)
                     return try await Self.method(.PUT,
                                                  path,
                                                  name: name,

--- a/Sources/ParseServerSwift/Models/HookFunction.swift
+++ b/Sources/ParseServerSwift/Models/HookFunction.swift
@@ -63,7 +63,7 @@ extension HookFunction {
                                           path,
                                           name: name,
                                           parseServerURLStrings: parseServerURLStrings)
-                    return try await Self.method(.PUT,
+                    return try await Self.method(method,
                                                  path,
                                                  name: name,
                                                  parseServerURLStrings: parseServerURLStrings)

--- a/Sources/ParseServerSwift/Models/HookFunction.swift
+++ b/Sources/ParseServerSwift/Models/HookFunction.swift
@@ -59,7 +59,8 @@ extension HookFunction {
                 if error.containedIn([.webhookError]) && method == .POST {
                     // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Function: \"\(String(describing: hookFunction))\"; warning: \(error); on server: \(parseServerURLString)")
-                    return try await Self.method(method, path,
+                    return try await Self.method(.PUT,
+                                                 path,
                                                  name: name,
                                                  parseServerURLStrings: parseServerURLStrings)
                 } else {

--- a/Sources/ParseServerSwift/Models/HookFunction.swift
+++ b/Sources/ParseServerSwift/Models/HookFunction.swift
@@ -59,6 +59,9 @@ extension HookFunction {
                 if error.containedIn([.webhookError]) && method == .POST {
                     // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Function: \"\(String(describing: hookFunction))\"; warning: \(error); on server: \(parseServerURLString)")
+                    return try await Self.method(method, path,
+                                                 name: name,
+                                                 parseServerURLStrings: parseServerURLStrings)
                 } else {
                     // swiftlint:disable:next line_length
                     configuration.logger.error("Could not \(method) Hook Function: \"\(String(describing: hookFunction))\"; error: \(error); on server: \(parseServerURLString)")

--- a/Sources/ParseServerSwift/Models/HookTrigger.swift
+++ b/Sources/ParseServerSwift/Models/HookTrigger.swift
@@ -74,7 +74,7 @@ extension HookTrigger {
                                           className: className,
                                           triggerName: triggerName,
                                           parseServerURLStrings: parseServerURLStrings)
-                    return try await Self.method(.PUT,
+                    return try await Self.method(method,
                                                  path,
                                                  className: className,
                                                  triggerName: triggerName,

--- a/Sources/ParseServerSwift/Models/HookTrigger.swift
+++ b/Sources/ParseServerSwift/Models/HookTrigger.swift
@@ -69,6 +69,10 @@ extension HookTrigger {
                 if error.containedIn([.webhookError]) && method == .POST {
                     // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Trigger: \"\(String(describing: hookTrigger))\"; warning: \(error); on server: \(parseServerURLString)")
+                    return try await Self.method(method, path,
+                                                 className: className,
+                                                 triggerName: triggerName,
+                                                 parseServerURLStrings: parseServerURLStrings)
                 } else {
                     // swiftlint:disable:next line_length
                     configuration.logger.error("Could not \(method) Hook Trigger: \"\(String(describing: hookTrigger))\"; error: \(error); on server: \(parseServerURLString)")

--- a/Sources/ParseServerSwift/Models/HookTrigger.swift
+++ b/Sources/ParseServerSwift/Models/HookTrigger.swift
@@ -69,7 +69,8 @@ extension HookTrigger {
                 if error.containedIn([.webhookError]) && method == .POST {
                     // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Trigger: \"\(String(describing: hookTrigger))\"; warning: \(error); on server: \(parseServerURLString)")
-                    return try await Self.method(method, path,
+                    return try await Self.method(.PUT,
+                                                 path,
                                                  className: className,
                                                  triggerName: triggerName,
                                                  parseServerURLStrings: parseServerURLStrings)

--- a/Sources/ParseServerSwift/Models/HookTrigger.swift
+++ b/Sources/ParseServerSwift/Models/HookTrigger.swift
@@ -69,6 +69,11 @@ extension HookTrigger {
                 if error.containedIn([.webhookError]) && method == .POST {
                     // swiftlint:disable:next line_length
                     configuration.logger.warning("Hook Trigger: \"\(String(describing: hookTrigger))\"; warning: \(error); on server: \(parseServerURLString)")
+                    try await Self.method(.DELETE,
+                                          path,
+                                          className: className,
+                                          triggerName: triggerName,
+                                          parseServerURLStrings: parseServerURLStrings)
                     return try await Self.method(.PUT,
                                                  path,
                                                  className: className,


### PR DESCRIPTION
- [x] When ParseServerSwift starts, it will 1) detect if a hook already exists on a node ParseServer, 2) delete the current hook 3) create a new hook. This prevents the node ParseServer from accidentally using a stale hook and polluting the Dashboard with multiple versions of the same hook