### PR TITLE
fix: Use route path in ParseHookTrigger

### DIFF
--- a/Sources/ParseServerSwift/Extensions/ParseHookTrigger+Vapor.swift
+++ b/Sources/ParseServerSwift/Extensions/ParseHookTrigger+Vapor.swift
@@ -1184,7 +1184,7 @@ public extension RoutesBuilder {
         let route = self.on(.POST, path, body: body, use: closure)
         Task {
             do {
-                await configuration.hooks.updateTriggers(try await ParseHookTrigger.create(path,
+                await configuration.hooks.updateTriggers(try await ParseHookTrigger.create(route.path,
                                                                                            className: className,
                                                                                            trigger: trigger))
             } catch {


### PR DESCRIPTION
Copy fix for #41 and apply it to ParseHookTrigger