### PR TITLE
fix: Set default port to 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,9 @@ COPY --from=build --chown=vapor:vapor /staging /app
 # Ensure all further commands run as the vapor user
 USER vapor:vapor
 
-# Let Docker bind to port 8081
-EXPOSE 8081
+# Let Docker bind to port 8080
+EXPOSE 8080
 
 # Start the Vapor service when the image is run, default to listening on 8081 in production environment
 ENTRYPOINT ["./App"]
-CMD ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8081"]
+CMD ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8080"]

--- a/Sources/ParseServerSwift/Documentation.docc/Configuring Parse Server Swift.tutorial
+++ b/Sources/ParseServerSwift/Documentation.docc/Configuring Parse Server Swift.tutorial
@@ -14,10 +14,10 @@
     @Section(title: "Hostname, Port, and TLS") {
         @Steps {
             @Step {
-                By default, the hostname is `127.0.0.1` and the port is `8081`. These values can easily be changed:
+                By default, the hostname is `127.0.0.1` and the port is `8080`. These values can easily be changed:
                 ```swift
                 app.http.server.configuration.hostname = "your.hostname.com"
-                app.http.server.configuration.port = 8081
+                app.http.server.configuration.port = 8080
                 app.http.server.configuration.tlsConfiguration = .none
                 ```
             }

--- a/Sources/ParseServerSwift/ParseServerConfiguration.swift
+++ b/Sources/ParseServerSwift/ParseServerConfiguration.swift
@@ -56,7 +56,7 @@ public struct ParseServerConfiguration {
         self.applicationId = applicationId
         self.primaryKey = primaryKey
         app.http.server.configuration.hostname = Environment.process.PARSE_SERVER_SWIFT_HOST_NAME ?? "localhost"
-        app.http.server.configuration.port = Int(Environment.process.PARSE_SERVER_SWIFT_PORT ?? 8081)
+        app.http.server.configuration.port = Int(Environment.process.PARSE_SERVER_SWIFT_PORT ?? 8080)
         app.http.server.configuration.tlsConfiguration = tlsConfiguration
         // swiftlint:disable:next line_length
         app.routes.defaultMaxBodySize = ByteCount(stringLiteral: Environment.process.PARSE_SERVER_SWIFT_DEFAULT_MAX_BODY_SIZE ?? "16kb")
@@ -90,7 +90,7 @@ public struct ParseServerConfiguration {
      */
     public init(app: Application,
                 hostName: String = "localhost",
-                port: Int = 8081,
+                port: Int = 8080,
                 tlsConfiguration: TLSConfiguration? = nil,
                 maxBodySize: ByteCount = "16kb",
                 applicationId: String,

--- a/Tests/ParseServerSwiftTests/AppTests.swift
+++ b/Tests/ParseServerSwiftTests/AppTests.swift
@@ -13,7 +13,7 @@ final class AppTests: XCTestCase {
         let app = Application(.testing)
         let configuration = try ParseServerConfiguration(app: app,
                                                          hostName: "hostName",
-                                                         port: 8081,
+                                                         port: 8080,
                                                          applicationId: "applicationId",
                                                          primaryKey: "primaryKey",
                                                          webhookKey: hookKey,
@@ -46,7 +46,7 @@ final class AppTests: XCTestCase {
         defer { app.shutdown() }
         let configuration = try ParseServerConfiguration(app: app,
                                                          hostName: "hostName",
-                                                         port: 8081,
+                                                         port: 8080,
                                                          applicationId: "applicationId",
                                                          primaryKey: "primaryKey",
                                                          parseServerURLString: "primaryKey")
@@ -58,7 +58,7 @@ final class AppTests: XCTestCase {
         defer { app.shutdown() }
         let configuration = try ParseServerConfiguration(app: app,
                                                          hostName: "hostName",
-                                                         port: 8081,
+                                                         port: 8080,
                                                          applicationId: "applicationId",
                                                          primaryKey: "primaryKey",
                                                          parseServerURLString: "primaryKey")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,17 +57,17 @@ services:
     environment:
       <<: *shared_environment
       PARSE_SERVER_SWIFT_HOST_NAME: cloud-code # Should be same name as docker service
-      PARSE_SERVER_SWIFT_PORT: 8081
+      PARSE_SERVER_SWIFT_PORT: 8080
       PARSE_SERVER_SWIFT_DEFAULT_MAX_BODY_SIZE: 16kb
       PARSE_SERVER_SWIFT_URLS: http://parse:1337/parse #,http://parse2:1337/parse # Only need to list one server.
       PARSE_SERVER_SWIFT_APPLICATION_ID: ${PARSE_SERVER_APPLICATION_ID}
       PARSE_SERVER_SWIFT_PRIMARY_KEY: ${PARSE_SERVER_PRIMARY_KEY}
       PARSE_SERVER_SWIFT_WEBHOOK_KEY: ${PARSE_SERVER_WEBHOOK_KEY}
     # ports:
-    #  - '8081:8081'
+    #  - '8081:8080'
     # user: '0' # uncomment to run as root for testing purposes even though Dockerfile defines 'vapor' user.
     restart: always
-    command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8081"]
+    command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8080"]
     # volumes:
     #  - ./.env:/app/.env
     #  - ./.env.production:/app/.env.production # Mount production environment if you have one.


### PR DESCRIPTION
Switch default port back to vapor default, 8080. See more here: https://docs.vapor.codes/advanced/server/?h=8080#port and https://docs.vapor.codes/deploy/nginx/?h=8080#more-detail. 

Hostname and port can be set via environment variables https://github.com/netreconlab/parse-server-swift/blob/8cdfa86385aeebb4a52f71bc555851f8913814ea/docker-compose.yml#L59-L60

Be sure to make any applicable changes to the docker files:
https://github.com/netreconlab/parse-server-swift/blob/8cdfa86385aeebb4a52f71bc555851f8913814ea/docker-compose.yml#L70

https://github.com/netreconlab/parse-server-swift/blob/8cdfa86385aeebb4a52f71bc555851f8913814ea/Dockerfile#L77-L81